### PR TITLE
Update testee to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/bitovi/grunt-testee/issues"
   },
   "dependencies": {
-    "testee": "^0.8.0"
+    "testee": "^0.9.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
This upgrades testee to the latest version. I need to be able to pass `reporterOptions`, which was just added recently.